### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Build limitador-driver
+FROM rust:1.76-bullseye as builder
+
+RUN apt update && apt upgrade -y \
+    && apt install -y protobuf-compiler
+
+WORKDIR /usr/src/limitador-driver
+COPY . .
+RUN cargo build --release
+
+# Stage 2: Setup the environment to run limitador-driver and limitador
+FROM rust:1.76-bullseye
+
+WORKDIR /bench
+
+# Copy the Rust binary from the builder stage
+COPY --from=builder /usr/src/limitador-driver/target/release/limitador-driver /bench/
+
+# Copy the limits.yaml to configure limitador
+COPY limits.yaml /bench
+
+# Copy the limitador service into the container
+COPY --from=quay.io/kuadrant/limitador:latest /home/limitador/bin/limitador-server /bench/limitador-server
+
+# Copy the script to start both services
+COPY start.sh /bench/start.sh
+RUN chmod +x /bench/start.sh
+
+# Run the script
+CMD ["/bench/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY start.sh /bench/start.sh
 RUN chmod +x /bench/start.sh
 
 # Run the script
-CMD ["/bench/start.sh"]
+ENTRYPOINT ["/bin/bash", "-c", "/bench/start.sh \"$@\"", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=builder /usr/src/limitador-driver/target/release/limitador-driver /b
 COPY limits.yaml /bench
 
 # Copy the limitador service into the container
-COPY --from=quay.io/kuadrant/limitador:latest /home/limitador/bin/limitador-server /bench/limitador-server
+COPY --from=quay.io/kuadrant/limitador:write-behind-lock /home/limitador/bin/limitador-server /bench/limitador-server
 
 # Copy the script to start both services
 COPY start.sh /bench/start.sh

--- a/limits.yaml
+++ b/limits.yaml
@@ -1,0 +1,7 @@
+---
+-
+  namespace: test_namespace
+  max_value: 100000
+  seconds: 5
+  conditions:
+  variables:

--- a/limits.yaml
+++ b/limits.yaml
@@ -1,7 +1,16 @@
 ---
--
-  namespace: test_namespace
+- namespace: test_namespace
   max_value: 100000
   seconds: 5
+  conditions:
+  variables:
+- namespace: test_namespace
+  max_value: 100000
+  seconds: 4
+  conditions:
+  variables:
+- namespace: test_namespace
+  max_value: 100000
+  seconds: 3
   conditions:
   variables:

--- a/start.sh
+++ b/start.sh
@@ -33,6 +33,8 @@ echo "Executing limitador: $ limitador-server /bench/limits.yaml $storage $stora
 # Start limitador in the background
 if [[ -z "$storage_url" ]]; then
     /bench/limitador-server /bench/limits.yaml "$storage" &
+elif [ "$storage" == "redis_cached" ]; then
+    /bench/limitador-server /bench/limits.yaml "$storage" "$storage_url" --ratio 1 &
 else
     /bench/limitador-server /bench/limits.yaml "$storage" "$storage_url" &
 fi

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Start limitador in the background
+/bench/limitador-server /bench/limits.yaml memory &
+
+# Wait for limitador to start
+sleep 5
+
+# Run limitador-driver
+/bench/limitador-driver rpc://127.0.0.1:8081 3m

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,46 @@
 #!/bin/bash
 
+# Default values
+DEFAULT_STORAGE="memory"
+DEFAULT_STORAGE_URL=""
+DEFAULT_TIME="3m"
+
+storage=$DEFAULT_STORAGE
+storage_url=$DEFAULT_STORAGE_URL
+time=$DEFAULT_TIME
+
+# Function to parse key-value pairs
+parse_arguments() {
+    echo "Parsing arguments"
+    for argument in "$@"
+    do
+        key=$(echo $argument | cut -f1 -d=)
+        value=$(echo $argument | cut -f2- -d=)
+
+        case "$key" in
+            "storage")        storage="$value" ;;
+            "storage_url")    storage_url="$value" ;;
+            "time")           time="$value" ;;
+            *)             echo "Unknown argument: $key" ;;
+        esac
+    done
+}
+
+parse_arguments "$@"
+
+echo "Executing limitador: $ limitador-server /bench/limits.yaml $storage $storage_url"
+
 # Start limitador in the background
-/bench/limitador-server /bench/limits.yaml memory &
+if [[ -z "$storage_url" ]]; then
+    /bench/limitador-server /bench/limits.yaml "$storage" &
+else
+    /bench/limitador-server /bench/limits.yaml "$storage" "$storage_url" &
+fi
 
 # Wait for limitador to start
 sleep 5
 
+echo "Executing limitador-driver: $ limitador-driver rpc://127.0.0.1:8081 $time"
+
 # Run limitador-driver
-/bench/limitador-driver rpc://127.0.0.1:8081 3m
+/bench/limitador-driver rpc://127.0.0.1:8081 "$time"


### PR DESCRIPTION
This PR introduces a Dockerfile for creating an image that will execute the driver and limitador in the same container. It's built with the option to be configurable by passing the following key=value pairs when ran:

1. Build the image
```sh
docker build -t limitador-driver:dev .
```

2. Run the driver
```sh
docker run limitador-driver:dev storage=memory time=1m
```

OR for setting up with redis:
```sh
docker run limitador-driver:dev storage=redis storage_url=rediss://[REDIS_URL]/#insecure time=1m
```


The result would look something like:

```sh
dd@pomodoro:~/Projects/RedHat/limitador-driver|docker ⇒  docker run limitador-driver:dev storage=memory time=1m
Parsing arguments
Executing limitador: $ limitador-server /bench/limits.yaml memory
Limitador Server v1.4.0-dev (b47cabab) [] release
Executing limitador-driver: $ limitador-driver rpc://127.0.0.1:8081 1m
Hitting Limitador at rpc://127.0.0.1:8081 for a total duration of 1 minutes
Current: hits: 6956, mean: 0.143ms, p50: 0.138ms, p90: 0.165ms, p99: 0.223ms, p999: 0.329ms, max: 1.279ms
Current: hits: 7148, mean: 0.139ms, p50: 0.136ms, p90: 0.158ms, p99: 0.185ms, p999: 0.227ms, max: 0.531ms
Current: hits: 6845, mean: 0.145ms, p50: 0.141ms, p90: 0.169ms, p99: 0.228ms, p999: 0.349ms, max: 0.405ms
Current: hits: 7093, mean: 0.140ms, p50: 0.137ms, p90: 0.160ms, p99: 0.192ms, p999: 0.229ms, max: 0.299ms
Current: hits: 6892, mean: 0.144ms, p50: 0.140ms, p90: 0.165ms, p99: 0.212ms, p999: 0.277ms, max: 0.361ms
Current: hits: 7034, mean: 0.141ms, p50: 0.138ms, p90: 0.161ms, p99: 0.195ms, p999: 0.235ms, max: 0.267ms
Current: hits: 6997, mean: 0.142ms, p50: 0.138ms, p90: 0.161ms, p99: 0.200ms, p999: 0.315ms, max: 1.303ms
Current: hits: 6956, mean: 0.143ms, p50: 0.138ms, p90: 0.165ms, p99: 0.213ms, p999: 0.327ms, max: 1.591ms
Current: hits: 6900, mean: 0.144ms, p50: 0.139ms, p90: 0.167ms, p99: 0.219ms, p999: 0.367ms, max: 3.279ms
Current: hits: 7127, mean: 0.140ms, p50: 0.137ms, p90: 0.159ms, p99: 0.189ms, p999: 0.227ms, max: 0.275ms
Current: hits: 7001, mean: 0.142ms, p50: 0.138ms, p90: 0.161ms, p99: 0.196ms, p999: 0.397ms, max: 0.951ms
Current: hits: 6849, mean: 0.145ms, p50: 0.141ms, p90: 0.167ms, p99: 0.218ms, p999: 0.289ms, max: 0.331ms
Current: hits: 6964, mean: 0.143ms, p50: 0.138ms, p90: 0.163ms, p99: 0.206ms, p999: 0.271ms, max: 0.405ms
Current: hits: 6951, mean: 0.143ms, p50: 0.139ms, p90: 0.163ms, p99: 0.203ms, p999: 0.265ms, max: 0.387ms
Current: hits: 6981, mean: 0.142ms, p50: 0.138ms, p90: 0.163ms, p99: 0.205ms, p999: 0.261ms, max: 0.331ms
Current: hits: 6891, mean: 0.144ms, p50: 0.139ms, p90: 0.166ms, p99: 0.222ms, p999: 0.339ms, max: 0.911ms
Current: hits: 6482, mean: 0.153ms, p50: 0.143ms, p90: 0.176ms, p99: 0.309ms, p999: 1.383ms, max: 6.975ms
Current: hits: 7762, mean: 0.128ms, p50: 0.128ms, p90: 0.157ms, p99: 0.187ms, p999: 0.223ms, max: 0.347ms
Current: hits: 7375, mean: 0.135ms, p50: 0.134ms, p90: 0.167ms, p99: 0.223ms, p999: 0.341ms, max: 0.675ms
Current: hits: 7446, mean: 0.134ms, p50: 0.134ms, p90: 0.161ms, p99: 0.192ms, p999: 0.305ms, max: 2.063ms
Current: hits: 6564, mean: 0.152ms, p50: 0.149ms, p90: 0.172ms, p99: 0.211ms, p999: 0.403ms, max: 3.103ms
Current: hits: 6580, mean: 0.151ms, p50: 0.148ms, p90: 0.171ms, p99: 0.237ms, p999: 0.859ms, max: 2.895ms
Current: hits: 7791, mean: 0.128ms, p50: 0.127ms, p90: 0.157ms, p99: 0.181ms, p999: 0.218ms, max: 0.252ms
Current: hits: 6905, mean: 0.144ms, p50: 0.142ms, p90: 0.167ms, p99: 0.201ms, p999: 0.248ms, max: 0.295ms
Current: hits: 6892, mean: 0.144ms, p50: 0.141ms, p90: 0.168ms, p99: 0.214ms, p999: 0.281ms, max: 0.351ms
Current: hits: 6765, mean: 0.147ms, p50: 0.141ms, p90: 0.174ms, p99: 0.251ms, p999: 0.509ms, max: 1.471ms
Current: hits: 6768, mean: 0.148ms, p50: 0.141ms, p90: 0.168ms, p99: 0.218ms, p999: 0.421ms, max: 8.767ms
Current: hits: 5699, mean: 0.175ms, p50: 0.160ms, p90: 0.207ms, p99: 0.389ms, p999: 1.495ms, max: 9.343ms
Current: hits: 6181, mean: 0.161ms, p50: 0.155ms, p90: 0.193ms, p99: 0.279ms, p999: 0.419ms, max: 0.995ms
Current: hits: 7160, mean: 0.139ms, p50: 0.136ms, p90: 0.171ms, p99: 0.233ms, p999: 0.361ms, max: 0.437ms
Current: hits: 6578, mean: 0.151ms, p50: 0.143ms, p90: 0.190ms, p99: 0.349ms, p999: 0.879ms, max: 2.351ms
Current: hits: 6542, mean: 0.152ms, p50: 0.147ms, p90: 0.180ms, p99: 0.254ms, p999: 0.335ms, max: 0.481ms
Current: hits: 6754, mean: 0.147ms, p50: 0.143ms, p90: 0.180ms, p99: 0.263ms, p999: 0.435ms, max: 0.855ms
Current: hits: 6766, mean: 0.147ms, p50: 0.142ms, p90: 0.170ms, p99: 0.227ms, p999: 0.285ms, max: 0.395ms
Current: hits: 6720, mean: 0.148ms, p50: 0.144ms, p90: 0.178ms, p99: 0.242ms, p999: 0.349ms, max: 0.491ms
Current: hits: 6426, mean: 0.155ms, p50: 0.148ms, p90: 0.187ms, p99: 0.265ms, p999: 0.439ms, max: 0.571ms
Current: hits: 6726, mean: 0.148ms, p50: 0.143ms, p90: 0.172ms, p99: 0.226ms, p999: 0.287ms, max: 0.397ms
Current: hits: 6788, mean: 0.147ms, p50: 0.142ms, p90: 0.171ms, p99: 0.221ms, p999: 0.301ms, max: 0.383ms
Current: hits: 6861, mean: 0.145ms, p50: 0.141ms, p90: 0.168ms, p99: 0.213ms, p999: 0.291ms, max: 0.507ms
Current: hits: 6881, mean: 0.145ms, p50: 0.141ms, p90: 0.168ms, p99: 0.213ms, p999: 0.313ms, max: 0.421ms
Current: hits: 7012, mean: 0.142ms, p50: 0.138ms, p90: 0.160ms, p99: 0.189ms, p999: 0.385ms, max: 1.311ms
Current: hits: 6828, mean: 0.146ms, p50: 0.143ms, p90: 0.168ms, p99: 0.208ms, p999: 0.281ms, max: 0.367ms
Current: hits: 6784, mean: 0.147ms, p50: 0.141ms, p90: 0.169ms, p99: 0.235ms, p999: 0.457ms, max: 1.631ms
Current: hits: 6899, mean: 0.144ms, p50: 0.140ms, p90: 0.166ms, p99: 0.208ms, p999: 0.265ms, max: 0.377ms
Current: hits: 6973, mean: 0.143ms, p50: 0.138ms, p90: 0.162ms, p99: 0.202ms, p999: 0.377ms, max: 1.559ms
^CCurrent: hits: 7161, mean: 0.139ms, p50: 0.136ms, p90: 0.155ms, p99: 0.181ms, p999: 0.230ms, max: 0.523ms
Current: hits: 6860, mean: 0.145ms, p50: 0.138ms, p90: 0.166ms, p99: 0.236ms, p999: 0.425ms, max: 1.559ms
Current: hits: 6966, mean: 0.143ms, p50: 0.139ms, p90: 0.163ms, p99: 0.191ms, p999: 0.218ms, max: 0.248ms
Current: hits: 6674, mean: 0.149ms, p50: 0.142ms, p90: 0.175ms, p99: 0.275ms, p999: 0.743ms, max: 1.063ms
Current: hits: 6942, mean: 0.143ms, p50: 0.140ms, p90: 0.166ms, p99: 0.202ms, p999: 0.247ms, max: 0.271ms
Current: hits: 6714, mean: 0.148ms, p50: 0.142ms, p90: 0.175ms, p99: 0.315ms, p999: 0.867ms, max: 2.063ms
Current: hits: 6882, mean: 0.144ms, p50: 0.141ms, p90: 0.168ms, p99: 0.207ms, p999: 0.293ms, max: 0.979ms
Current: hits: 7071, mean: 0.141ms, p50: 0.137ms, p90: 0.160ms, p99: 0.202ms, p999: 0.259ms, max: 0.333ms
Current: hits: 7018, mean: 0.142ms, p50: 0.138ms, p90: 0.162ms, p99: 0.226ms, p999: 0.285ms, max: 0.463ms
Current: hits: 6925, mean: 0.144ms, p50: 0.139ms, p90: 0.165ms, p99: 0.204ms, p999: 0.267ms, max: 1.887ms
Current: hits: 7080, mean: 0.140ms, p50: 0.137ms, p90: 0.158ms, p99: 0.185ms, p999: 0.212ms, max: 0.253ms
Current: hits: 7018, mean: 0.142ms, p50: 0.138ms, p90: 0.161ms, p99: 0.191ms, p999: 0.220ms, max: 0.273ms
Current: hits: 6924, mean: 0.144ms, p50: 0.141ms, p90: 0.163ms, p99: 0.192ms, p999: 0.243ms, max: 0.391ms
Current: hits: 6961, mean: 0.143ms, p50: 0.139ms, p90: 0.163ms, p99: 0.197ms, p999: 0.269ms, max: 0.419ms


 ============== Done! =================

Ok: hits: 413423, mean: 0.144ms, p50: 0.140ms, p90: 0.168ms, p99: 0.223ms, p999: 0.389ms, max: 9.343ms
OverLimit: hits: 0, mean: 0.000ms, p50: 0.000ms, p90: 0.000ms, p99: 0.000ms, p999: 0.000ms, max: 0.000ms
Unknown: hits: 0, mean: 0.000ms, p50: 0.000ms, p90: 0.000ms, p99: 0.000ms, p999: 0.000ms, max: 0.000ms
Overall: hits: 413423, mean: 0.144ms, p50: 0.140ms, p90: 0.168ms, p99: 0.223ms, p999: 0.389ms, max: 9.343ms

0.02ms |                                                                                  |  0.0th %-ile
0.04ms |                                                                                  |  0.0th %-ile
0.07ms |                                                                                  |  0.0th %-ile
0.09ms | *                                                                                |  0.0th %-ile
0.11ms | ****                                                                             |  4.2th %-ile
0.13ms | ******************                                                               | 26.3th %-ile
0.15ms | ****************************************                                         | 75.3th %-ile
0.18ms | ***************                                                                  | 93.4th %-ile
0.20ms | ****                                                                             | 97.6th %-ile
0.22ms | **                                                                               | 98.9th %-ile
0.24ms | *                                                                                | 99.4th %-ile
0.26ms | *                                                                                | 99.6th %-ile
0.29ms | *                                                                                | 99.7th %-ile
0.31ms | *                                                                                | 99.8th %-ile
0.33ms | *                                                                                | 99.8th %-ile
0.35ms | *                                                                                | 99.9th %-ile
0.37ms | *                                                                                | 99.9th %-ile
0.40ms | *                                                                                | 99.9th %-ile
```